### PR TITLE
Change CMake compilation for any directory structure

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -1,13 +1,13 @@
 cmake_minimum_required (VERSION 2.6)
-project (BasicServer)
+project (Phaser)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
-set(USER_DIR /home/vagrant)
+set(USER_DIR ../..)
 
 set(SSL_DIR /usr/lib/x86_64-linux-gnu)
 set(Casablanca_DIR ${USER_DIR}/casablanca)
 set(Store_DIR ${USER_DIR}/azure-storage-cpp)
-set(Test_DIR ${USER_DIR}/cmpt276-projects/unittest-cpp)
+set(Test_DIR ${USER_DIR}/unittest-cpp)
 
 find_package(Boost REQUIRED COMPONENTS random chrono system thread regex filesystem)
 find_package(Threads REQUIRED)


### PR DESCRIPTION
As addressed in [this issue](https://github.com/CMPT276-2016spring/phaser/issues/22).

The default directory is no longer an absolute path.

The Casablanca and Azure Storage directories are now one directory closer to the repository than before - in the same directory as the UnitTest++ directory, for consistency.

New directory structure:

```
[parent_directory]
 ├ casablanca (C++ REST SDK)
 ├ azure-storage-cpp (Microsoft Azure Storage)
 ├ unittest-cpp (UnitTest++)
 └ phaser
```

I have also renamed the project in CMake as the project was originally named BasicServer when it was first conceived, but has grown beyond BasicServer.
